### PR TITLE
Add rule to ban Conventional Commits

### DIFF
--- a/src/danger_plugin_pr_hygiene/rules/no_conventional_commits.gleam
+++ b/src/danger_plugin_pr_hygiene/rules/no_conventional_commits.gleam
@@ -1,0 +1,42 @@
+import danger_plugin_pr_hygiene/emit_level.{type EmitLevel}
+import danger_plugin_pr_hygiene/rule.{type Violation, Violation}
+import gleam/regex
+import gleam/string
+
+pub type NoConventionalCommitsConfig {
+  NoConventionalCommitsConfig(
+    level: EmitLevel,
+    message: String,
+    banned_types: List(String),
+  )
+}
+
+pub fn default_config() -> NoConventionalCommitsConfig {
+  NoConventionalCommitsConfig(
+    level: emit_level.Warn,
+    message: "Do not use Conventional Commits in PR titles.",
+    banned_types: [
+      "feat", "fix", "docs", "style", "refactor", "perf", "test", "chore", "ci",
+      "build", "revert",
+    ],
+  )
+}
+
+pub fn no_conventional_commits(pr_title: String) -> Result(Nil, List(Violation)) {
+  let types = default_config().banned_types |> string.join("|")
+
+  let assert Ok(pattern) =
+    regex.from_string("^(" <> types <> ")(\\([a-z0-9-_]+\\))?:\\s.+")
+
+  case regex.check(pattern, pr_title) {
+    True -> {
+      let colon_position = case string.split_once(pr_title, on: ":") {
+        Ok(#(before, _)) -> string.length(before) + 1
+        Error(_) -> 0
+      }
+
+      Error([Violation(span: #(0, colon_position))])
+    }
+    False -> Ok(Nil)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,12 @@ import {
   Message,
   Warn,
 } from "../build/dev/javascript/danger_plugin_pr_hygiene/danger_plugin_pr_hygiene/emit_level.mjs";
+import { NoConventionalCommitsConfig as InternalNoConventionalCommitsConfig } from "../build/dev/javascript/danger_plugin_pr_hygiene/danger_plugin_pr_hygiene/rules/no_conventional_commits.mjs";
 import { NoTrailingPunctuationConfig as InternalNoTrainingPunctuationConfig } from "../build/dev/javascript/danger_plugin_pr_hygiene/danger_plugin_pr_hygiene/rules/no_trailing_punctuation.mjs";
 import { RequirePrefixConfig as InternalRequirePrefixConfig } from "../build/dev/javascript/danger_plugin_pr_hygiene/danger_plugin_pr_hygiene/rules/require_prefix.mjs";
 import { UseImperativeMoodConfig as InternalUseImperativeMoodConfig } from "../build/dev/javascript/danger_plugin_pr_hygiene/danger_plugin_pr_hygiene/rules/use_imperative_mood.mjs";
 import { UseSentenceCaseConfig as InternalUseSentenceCaseConfig } from "../build/dev/javascript/danger_plugin_pr_hygiene/danger_plugin_pr_hygiene/rules/use_sentence_case.mjs";
+import { to_list as array_to_list } from "../build/dev/javascript/gleam_javascript/gleam/javascript/array.mjs";
 
 declare var danger: DangerDSLType;
 declare function message(message: string): undefined;
@@ -48,6 +50,12 @@ export interface NoTrailingPunctuationConfig {
   message: string;
 }
 
+export interface NoConventionalCommitsConfig {
+  level: EmitLevel;
+  message: string;
+  bannedTypes: string[];
+}
+
 export type ConfigurationOrOff<T> = T | "off";
 
 export type PartialConfigurationOrOff<T> = ConfigurationOrOff<Partial<T>>;
@@ -59,6 +67,7 @@ export interface PrHygieneOptions {
     useImperativeMood?: PartialConfigurationOrOff<UseImperativeMoodConfig>;
     useSentenceCase?: PartialConfigurationOrOff<UseSentenceCaseConfig>;
     noTrailingPunctuation?: PartialConfigurationOrOff<NoTrailingPunctuationConfig>;
+    noConventionalCommits?: PartialConfigurationOrOff<NoConventionalCommitsConfig>;
   };
 }
 
@@ -107,6 +116,18 @@ export function prHygiene(options: PrHygieneOptions = {}): void {
             new InternalNoTrainingPunctuationConfig(
               level ? toInternalEmitLevel(level) : defaultConfig.level,
               message ?? defaultConfig.message,
+            ),
+        ),
+        applyConfiguration(
+          options?.rules?.noConventionalCommits,
+          defaultOptions.rules.no_conventional_commits,
+          ({ level, message, bannedTypes }, defaultConfig) =>
+            new InternalNoConventionalCommitsConfig(
+              level ? toInternalEmitLevel(level) : defaultConfig.level,
+              message ?? defaultConfig.message,
+              bannedTypes
+                ? array_to_list(bannedTypes)
+                : defaultConfig.banned_types,
             ),
         ),
       ),

--- a/test/danger_plugin_pr_hygiene/rules/no_conventional_commits_test.gleam
+++ b/test/danger_plugin_pr_hygiene/rules/no_conventional_commits_test.gleam
@@ -1,0 +1,56 @@
+import danger_plugin_pr_hygiene/rule.{Violation}
+import danger_plugin_pr_hygiene/rules/no_conventional_commits.{
+  no_conventional_commits,
+}
+import gleam/list
+import gleam/string
+import startest.{describe, it}
+import startest/expect
+
+pub fn no_conventional_commits_tests() {
+  describe("danger_plugin_pr_hygiene/rules/no_conventional_commits", [
+    describe("no_conventional_commits", [
+      describe(
+        "when the PR title does not start with a Conventional Commits prefix",
+        [
+          it("returns Ok", fn() {
+            no_conventional_commits("Update the build script")
+            |> expect.to_be_ok
+          }),
+        ],
+      ),
+      ..no_conventional_commits.default_config().banned_types
+      |> list.flat_map(fn(prefix) {
+        let prefix_with_scope = prefix <> "(scope)"
+
+        [
+          describe("when the PR title starts with `" <> prefix <> "`", [
+            it("returns an Error containing a violation", fn() {
+              let base_title = "Update the build script"
+
+              no_conventional_commits(prefix <> ": " <> base_title)
+              |> expect.to_be_error
+              |> expect.to_equal([
+                Violation(span: #(0, string.length(prefix) + 1)),
+              ])
+            }),
+          ]),
+          describe(
+            "when the PR title starts with `" <> prefix_with_scope <> "`",
+            [
+              it("returns an Error containing a violation", fn() {
+                let base_title = "Update the build script"
+
+                no_conventional_commits(prefix_with_scope <> ": " <> base_title)
+                |> expect.to_be_error
+                |> expect.to_equal([
+                  Violation(span: #(0, string.length(prefix_with_scope) + 1)),
+                ])
+              }),
+            ],
+          ),
+        ]
+      })
+    ]),
+  ])
+}

--- a/test/integration/no_conventional_commits_test.gleam
+++ b/test/integration/no_conventional_commits_test.gleam
@@ -1,0 +1,40 @@
+import danger_plugin_pr_hygiene.{
+  Config, PrHygieneOptions, PrHygieneRules, default_options,
+}
+import danger_plugin_pr_hygiene/rules/no_conventional_commits.{
+  NoConventionalCommitsConfig,
+}
+import test_helpers.{test_rule}
+
+const passing_pr_titles = [
+  "Send an email to the customer when a product is shipped",
+  "api: Add a new endpoint",
+]
+
+const failing_pr_titles = [
+  "chore: Bump version",
+  "feat: Allow provided config object to extend other configs",
+  "feat(lang): Add Polish language",
+]
+
+pub fn no_conventional_commits_tests() {
+  test_rule(
+    "No Conventional Commits",
+    config: fn(level) {
+      PrHygieneOptions(
+        ..default_options(),
+        rules: PrHygieneRules(
+          ..default_options().rules,
+          no_conventional_commits: Config(
+            NoConventionalCommitsConfig(
+              ..no_conventional_commits.default_config(),
+              level:,
+            ),
+          ),
+        ),
+      )
+    },
+    passing: passing_pr_titles,
+    failing: failing_pr_titles,
+  )
+}


### PR DESCRIPTION
This PR adds a rule to ban PR titles using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).